### PR TITLE
Add in ability to build solana binary from local repo on host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -363,6 +367,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +556,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -640,6 +678,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +804,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -851,6 +941,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
@@ -1223,6 +1319,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,10 +1498,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1411,10 +1537,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "validator-lab"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "git2",
  "k8s-openapi",
  "kube",
  "log",
@@ -1422,6 +1560,12 @@ dependencies = [
  "solana-logger",
  "tokio",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 clap = "2.33.1"
+git2 = "0.18.3"
 k8s-openapi ={ version = "0.20.0", features = ["v1_28"] }
 kube = "0.87.2"
 log = "0.4.21"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,7 +10,7 @@
 ## Steps
 - [x] Connect to kubernetes endpoint and check if namespace exists
 - [ ] Setup build config Local
-    - [ ] Build from local commit
+    - [x] Build from local commit
     - [ ] Build from tar (release version)
 - [ ] Create Genesis
     - [ ] Generate faucet and bootstrap accounts

--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ kubectl create ns <namespace>
 ### Run
 ```
 cargo run --bin cluster --
-    -n <namespace e.g. cluster-test>
+    -n <namespace>
+    --deploy-method local
+    --local-path <path-to-local-agave-monorepo>
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,40 @@
+use std::{env, path::PathBuf};
+
+#[macro_export]
+macro_rules! boxed_error {
+    ($message:expr) => {
+        Box::new(std::io::Error::new(std::io::ErrorKind::Other, $message)) as Box<dyn Error + Send>
+    };
+}
+
+pub fn get_solana_root() -> PathBuf {
+    PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to get Solana root directory")
+        .to_path_buf()
+}
+
+pub struct SolanaRoot {
+    root_path: PathBuf,
+}
+
+impl Default for SolanaRoot {
+    fn default() -> Self {
+        Self {
+            root_path: get_solana_root(),
+        }
+    }
+}
+
+impl SolanaRoot {
+    pub fn new_from_path(path: PathBuf) -> Self {
+        Self { root_path: path }
+    }
+
+    pub fn get_root_path(&self) -> PathBuf {
+        self.root_path.clone()
+    }
+}
+
 pub mod kubernetes;
+pub mod release;

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,148 @@
+use {
+    crate::boxed_error,
+    git2::Repository,
+    log::*,
+    std::{error::Error, fmt::Display, path::PathBuf, str::FromStr, time::Instant},
+};
+
+#[derive(Debug)]
+pub enum DeployMethod {
+    Local,
+    Tar,
+    Skip,
+}
+
+impl Display for DeployMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeployMethod::Local => write!(f, "local"),
+            DeployMethod::Tar => write!(f, "tar"),
+            DeployMethod::Skip => write!(f, "skip"),
+        }
+    }
+}
+
+impl FromStr for DeployMethod {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "local" => Ok(DeployMethod::Local),
+            "tar" => Ok(DeployMethod::Tar),
+            "skip" => Ok(DeployMethod::Skip),
+            _ => Err(()),
+        }
+    }
+}
+
+pub struct BuildConfig {
+    deploy_method: DeployMethod,
+    skip_build: bool,
+    debug_build: bool,
+    _build_path: PathBuf,
+    solana_root_path: PathBuf,
+}
+
+impl BuildConfig {
+    pub fn new(
+        deploy_method: &str,
+        skip_build: bool,
+        debug_build: bool,
+        solana_root_path: &PathBuf,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let deploy_method = deploy_method
+            .parse::<DeployMethod>()
+            .map_err(|_| "Failed to parse deploy_method".to_string())?;
+
+        let build_path = match deploy_method {
+            DeployMethod::Local => solana_root_path.join("farf/bin"),
+            DeployMethod::Tar => solana_root_path.join("solana-release/bin"),
+            DeployMethod::Skip => solana_root_path.join("farf/bin"),
+        };
+
+        Ok(BuildConfig {
+            deploy_method,
+            skip_build,
+            debug_build,
+            _build_path: build_path,
+            solana_root_path: solana_root_path.clone(),
+        })
+    }
+
+    pub async fn prepare(&self) -> Result<(), Box<dyn Error>> {
+        match self.deploy_method {
+            DeployMethod::Tar => {
+                return Err(boxed_error!("Tar deploy method not implemented yet."));
+            }
+            DeployMethod::Local => {
+                self.setup_local_deploy()?;
+            }
+            DeployMethod::Skip => {
+                return Err(boxed_error!("Skip deploy method not implemented yet."));
+            }
+        }
+        info!("Completed Prepare Deploy");
+        Ok(())
+    }
+
+    fn setup_local_deploy(&self) -> Result<(), Box<dyn Error>> {
+        if !self.skip_build {
+            self.build()?;
+        } else {
+            info!("Build skipped due to --skip-build");
+        }
+        Ok(())
+    }
+
+    fn build(&self) -> Result<(), Box<dyn Error>> {
+        let start_time = Instant::now();
+        let build_variant = if self.debug_build { "--debug" } else { "" };
+
+        let install_directory = self.solana_root_path.join("farf");
+        let install_script = self.solana_root_path.join("scripts/cargo-install-all.sh");
+        match std::process::Command::new(install_script)
+            .arg(install_directory)
+            .arg(build_variant)
+            .arg("--validator-only")
+            .status()
+        {
+            Ok(result) => {
+                if result.success() {
+                    info!("Successfully built validator")
+                } else {
+                    return Err(boxed_error!("Failed to build validator"));
+                }
+            }
+            Err(err) => return Err(Box::new(err)),
+        }
+
+        let solana_repo = Repository::open(self.solana_root_path.as_path())?;
+        let commit = solana_repo.revparse_single("HEAD")?.id();
+        let branch = solana_repo
+            .head()?
+            .shorthand()
+            .expect("Failed to get shortened branch name")
+            .to_string();
+
+        // Check if current commit is associated with a tag
+        let mut note = branch;
+        for tag in (&solana_repo.tag_names(None)?).into_iter().flatten() {
+            // Get the target object of the tag
+            let tag_object = solana_repo.revparse_single(tag)?.id();
+            // Check if the commit associated with the tag is the same as the current commit
+            if tag_object == commit {
+                info!("The current commit is associated with tag: {}", tag);
+                note = tag_object.to_string();
+                break;
+            }
+        }
+
+        // Write to branch/tag and commit to version.yml
+        let content = format!("channel: devbuild {}\ncommit: {}", note, commit);
+        std::fs::write(self.solana_root_path.join("farf/version.yml"), content)
+            .expect("Failed to write version.yml");
+
+        info!("Build took {:.3?} seconds", start_time.elapsed());
+        Ok(())
+    }
+}


### PR DESCRIPTION
#### Summary of Changes
1) Add in build solana binary from local repo on host

2nd PR in a series of PRs that will build out the mongon testing framework for deploying validator clusters on Kubernetes
Previous PRs:
1) PR: https://github.com/anza-xyz/validator-lab/pull/1

Build repo from local solana repo. so pass in a path via `--local-path <path-to-local-agave-monorepo>` to let this repo know which repo you want to build. 