### PR TITLE
add and deploy bootstrap secrets

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -19,7 +19,7 @@
     - [x] Build Bootstrap Image
     - [x] Push Image to registry
 - [ ] Create & Deploy Secrets
-    - [ ] Bootstrap
+    - [x] Bootstrap
     - [ ] Validator (regular)
     - [ ] RPC nodes
     - [ ] Client

--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ kubectl create ns <namespace>
 cargo run --bin cluster --
     -n <namespace>
     --local-path <path-to-local-agave-monorepo>
+    --validator-lab-dir <path-to-validator-lab-directory>
 ```
 
 #### Build specific Agave release
 ```
 cargo run --bin cluster --
     -n <namespace>
-    --release-channel <agave-version: e.g. v1.17.28> # note: MUST include the "v" 
+    --release-channel <agave-version: e.g. v1.17.28> # note: MUST include the "v"
+    --validator-lab-dir <path-to-validator-lab-directory>
 ```
 
 #### Build from Local Repo and Configure Genesis and Bootstrap Validator Image
@@ -42,6 +44,7 @@ Example:
 cargo run --bin cluster -- 
     -n <namespace> 
     --local-path /home/sol/solana
+    --validator-lab-dir /home/sol/validator-lab
     # genesis config. Optional: Many of these have defaults
     --hashes-per-tick <hashes-per-tick>
     --enable-warmup-epochs <true|false>

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -99,8 +99,7 @@ pub struct Genesis {
 }
 
 impl Genesis {
-    pub fn new(solana_root: &Path, flags: GenesisFlags) -> Self {
-        let config_dir = solana_root.join("config-k8s");
+    pub fn new(config_dir: PathBuf, flags: GenesisFlags) -> Self {
         if config_dir.exists() {
             std::fs::remove_dir_all(&config_dir).unwrap();
         }

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -1,0 +1,30 @@
+use {
+    k8s_openapi::{api::core::v1::Secret, ByteString},
+    kube::api::ObjectMeta,
+    std::{collections::BTreeMap, error::Error, path::PathBuf},
+};
+
+fn create_secret(name: &str, data: BTreeMap<String, ByteString>) -> Secret {
+    Secret {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    }
+}
+
+pub fn create_secret_from_files(
+    secret_name: &str,
+    key_files: &[(PathBuf, &str)], //[pathbuf, key type]
+) -> Result<Secret, Box<dyn Error>> {
+    let mut data = BTreeMap::new();
+    for (file_path, key_type) in key_files {
+        let file_content = std::fs::read(file_path)
+            .map_err(|err| format!("Failed to read file '{:?}': {}", file_path, err))?;
+        data.insert(format!("{}.json", key_type), ByteString(file_content));
+    }
+
+    Ok(create_secret(secret_name, data))
+}

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -1,9 +1,11 @@
 use {
-    k8s_openapi::api::core::v1::Namespace,
+    crate::k8s_helpers,
+    k8s_openapi::api::core::v1::{Namespace, Secret},
     kube::{
-        api::{Api, ListParams},
+        api::{Api, ListParams, PostParams},
         Client,
     },
+    std::{error::Error, path::Path},
 };
 
 pub struct Kubernetes {
@@ -29,5 +31,31 @@ impl Kubernetes {
             .any(|ns| ns.metadata.name.as_ref() == Some(&self.namespace));
 
         Ok(exists)
+    }
+
+    pub fn create_bootstrap_secret(
+        &self,
+        secret_name: &str,
+        config_dir: &Path,
+    ) -> Result<Secret, Box<dyn Error>> {
+        let faucet_key_path = config_dir.join("faucet.json");
+        let identity_key_path = config_dir.join("bootstrap-validator/identity.json");
+        let vote_key_path = config_dir.join("bootstrap-validator/vote-account.json");
+        let stake_key_path = config_dir.join("bootstrap-validator/stake-account.json");
+
+        let key_files = vec![
+            (faucet_key_path, "faucet"),
+            (identity_key_path, "identity"),
+            (vote_key_path, "vote"),
+            (stake_key_path, "stake"),
+        ];
+
+        k8s_helpers::create_secret_from_files(secret_name, &key_files)
+    }
+
+    pub async fn deploy_secret(&self, secret: &Secret) -> Result<Secret, kube::Error> {
+        let secrets_api: Api<Secret> =
+            Api::namespaced(self.k8s_client.clone(), self.namespace.as_str());
+        secrets_api.create(&PostParams::default(), secret).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use {
     log::*,
     reqwest::Client,
     std::{
-        env,
         fs::File,
         io::{BufReader, Cursor, Read, Write},
         path::{Path, PathBuf},
@@ -18,20 +17,14 @@ use {
 
 const UPGRADEABLE_LOADER: &str = "BPFLoaderUpgradeab1e11111111111111111111111";
 
-pub fn get_solana_root() -> PathBuf {
-    PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR")).to_path_buf()
+#[derive(Clone, Debug)]
+pub struct EnvironmentConfig<'a> {
+    pub namespace: &'a str,
+    pub lab_path: PathBuf, // path to the validator-lab directory
 }
 
 pub struct SolanaRoot {
     root_path: PathBuf,
-}
-
-impl Default for SolanaRoot {
-    fn default() -> Self {
-        Self {
-            root_path: get_solana_root(),
-        }
-    }
 }
 
 impl SolanaRoot {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub enum ValidatorType {
 
 pub mod docker;
 pub mod genesis;
+pub mod k8s_helpers;
 pub mod kubernetes;
 pub mod release;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use {
         },
         kubernetes::Kubernetes,
         release::{BuildConfig, BuildType, DeployMethod},
-        SolanaRoot, ValidatorType,
+        EnvironmentConfig, SolanaRoot, ValidatorType,
     },
 };
 
@@ -49,6 +49,14 @@ fn parse_matches() -> clap::ArgMatches {
             ArgGroup::new("required_group")
                 .args(&["local_path", "release_channel"])
                 .required(true),
+        )
+        .arg(
+            Arg::with_name("validator_lab_directory")
+                .long("validator-lab-dir")
+                .takes_value(true)
+                .required(true)
+                .help("Absolute path to validator lab directory. 
+                e.g. /home/sol/validator-lab"),
         )
         // Genesis Config
         .arg(
@@ -151,11 +159,6 @@ fn parse_matches() -> clap::ArgMatches {
         .get_matches()
 }
 
-#[derive(Clone, Debug)]
-pub struct EnvironmentConfig<'a> {
-    pub namespace: &'a str,
-}
-
 #[tokio::main]
 async fn main() {
     if std::env::var("RUST_LOG").is_err() {
@@ -165,6 +168,7 @@ async fn main() {
     let matches = parse_matches();
     let environment_config = EnvironmentConfig {
         namespace: matches.value_of("cluster_namespace").unwrap_or_default(),
+        lab_path: matches.value_of("validator_lab_directory").unwrap().into(),
     };
 
     let deploy_method = if let Some(local_path) = matches.value_of("local_path") {
@@ -182,7 +186,7 @@ async fn main() {
             (root, path)
         }
         DeployMethod::ReleaseChannel(_) => {
-            let root = SolanaRoot::default();
+            let root = SolanaRoot::new_from_path(environment_config.lab_path.clone());
             let path = root.get_root_path().join("solana-release/bin");
             (root, path)
         }
@@ -193,14 +197,14 @@ async fn main() {
     if let Ok(metadata) = fs::metadata(solana_root.get_root_path()) {
         if !metadata.is_dir() {
             return error!(
-                "Build path is not a directory: {:?}",
-                solana_root.get_root_path()
+                "Build path is not a directory: {}",
+                solana_root.get_root_path().display()
             );
         }
     } else {
         return error!(
-            "Build directory not found: {:?}",
-            solana_root.get_root_path()
+            "Build directory not found: {}",
+            solana_root.get_root_path().display()
         );
     }
 
@@ -318,10 +322,7 @@ async fn main() {
 
     //unwraps are safe here. since their requirement is enforced by argmatches
     let docker = DockerConfig::new(
-        matches
-            .value_of("base_image")
-            .unwrap()
-            .to_string(),
+        matches.value_of("base_image").unwrap().to_string(),
         deploy_method,
     );
 
@@ -330,14 +331,15 @@ async fn main() {
         matches.value_of("registry_name").unwrap().to_string(),
         validator_type,
         matches.value_of("image_name").unwrap().to_string(),
-        matches
-            .value_of("image_tag")
-            .unwrap()
-            .to_string(),
+        matches.value_of("image_tag").unwrap().to_string(),
     );
 
     if build_config.docker_build() {
-        match docker.build_image(solana_root.get_root_path(), &docker_image) {
+        match docker.build_image(
+            solana_root.get_root_path(),
+            &environment_config.lab_path,
+            &docker_image,
+        ) {
             Ok(_) => info!("{} image built successfully", docker_image.validator_type()),
             Err(err) => {
                 error!("Exiting........ {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,7 +320,7 @@ async fn main() {
     let docker = DockerConfig::new(
         matches
             .value_of("base_image")
-            .unwrap_or_default()
+            .unwrap()
             .to_string(),
         deploy_method,
     );
@@ -332,7 +332,7 @@ async fn main() {
         matches.value_of("image_name").unwrap().to_string(),
         matches
             .value_of("image_tag")
-            .unwrap_or_default()
+            .unwrap()
             .to_string(),
     );
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -30,7 +30,7 @@ pub struct BuildConfig {
     build_type: BuildType,
     solana_root_path: PathBuf,
     docker_build: bool,
-    build_path: PathBuf,
+    _build_path: PathBuf,
 }
 
 impl BuildConfig {
@@ -50,12 +50,8 @@ impl BuildConfig {
             build_type,
             solana_root_path: solana_root_path.to_path_buf(),
             docker_build,
-            build_path,
+            _build_path: build_path,
         }
-    }
-
-    pub fn build_path(&self) -> PathBuf {
-        self.build_path.clone()
     }
 
     pub fn docker_build(&self) -> bool {
@@ -90,7 +86,10 @@ impl BuildConfig {
         let tarball_filename = self.solana_root_path.join(&tar_filename);
         let release_dir = self.solana_root_path.join(file_name);
         extract_release_archive(&tarball_filename, &self.solana_root_path).map_err(|err| {
-            format!("Unable to extract {tar_filename} into {release_dir:?}: {err}")
+            format!(
+                "Unable to extract {tar_filename} into {}: {err}",
+                release_dir.display()
+            )
         })?;
 
         Ok(release_dir)


### PR DESCRIPTION
#### Summary of Changes
1) create and deploy kubernetes secret for bootstrap accounts
2) fix some of @joncinque nits and remove dependency on `CARGO_MANIGEST_PATH`

8th PR in a series of PRs that will build out the monogon testing framework for deploying validator clusters on Kubernetes
Previous PRs:
1) PR: https://github.com/anza-xyz/validator-lab/pull/1
2) PR: https://github.com/anza-xyz/validator-lab/pull/2
3) PR: https://github.com/anza-xyz/validator-lab/pull/3
4) PR: https://github.com/anza-xyz/validator-lab/pull/4
5) PR: https://github.com/anza-xyz/validator-lab/pull/5
6) PR: https://github.com/anza-xyz/validator-lab/pull/6
7) PR: https://github.com/anza-xyz/validator-lab/pull/7