### PR TITLE
Create bootstrap replicaset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7137,6 +7137,7 @@ dependencies = [
  "rustc_version",
  "rustls",
  "solana-core",
+ "solana-ledger",
  "solana-logger",
  "solana-sdk",
  "strum 0.26.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "aquamarine"
@@ -7132,7 +7132,6 @@ dependencies = [
  "kube",
  "log",
  "rand 0.8.5",
- "rayon",
  "reqwest",
  "rustc_version",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ k8s-openapi ={ version = "0.20.0", features = ["v1_28"] }
 kube = "0.87.2"
 log = "0.4.21"
 rand = "0.8.5"
-rayon = "1.9.0"
 reqwest = { version = "0.11.23", features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 rustls = { version = "0.21.11", default-features = false, features = ["quic"] }
 solana-core = "1.18.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.9.0"
 reqwest = { version = "0.11.23", features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 rustls = { version = "0.21.11", default-features = false, features = ["quic"] }
 solana-core = "1.18.8"
+solana-ledger = "1.18.8"
 solana-logger = "1.18.8"
 solana-sdk = "1.18.8"
 strum = "0.26.2"

--- a/src/cluster_images.rs
+++ b/src/cluster_images.rs
@@ -9,36 +9,33 @@ use {
 // 3) RPC Node -> One image for each RPC node (not implemented yet)
 // 4) Clients -> Each client has its own image (not implemented yet)
 
-pub struct Library {
-    validators: Vec<Option<Validator>>,
-    _clients: Option<Vec<Validator>>,
+#[derive(Default)]
+pub struct ClusterImages {
+    bootstrap: Option<Validator>,
+    _validator: Option<Validator>,
+    _rpc: Option<Validator>,
+    _clients: Vec<Validator>,
 }
 
-impl Default for Library {
-    fn default() -> Self {
-        Self {
-            validators: vec![None; 1],
-            _clients: None,
-        }
-    }
-}
-
-impl Library {
+impl ClusterImages {
     pub fn set_item(&mut self, item: Validator, validator_type: ValidatorType) {
         match validator_type {
-            ValidatorType::Bootstrap => self.validators[0] = Some(item),
+            ValidatorType::Bootstrap => self.bootstrap = Some(item),
             _ => panic!("{validator_type} not implemented yet!"),
         }
     }
 
     pub fn bootstrap(&mut self) -> Result<&mut Validator, Box<dyn Error>> {
-        self.validators
-            .get_mut(0)
-            .and_then(Option::as_mut)
-            .ok_or_else(|| "No Bootstrap validator found.".to_string().into())
+        self.bootstrap
+            .as_mut()
+            .ok_or_else(|| "Bootstrap validator is not available".into())
     }
 
     pub fn get_validators(&self) -> impl Iterator<Item = &Validator> {
-        self.validators.iter().filter_map(Option::as_ref)
+        self.bootstrap
+            .iter()
+            .chain(self._validator.iter())
+            .chain(self._rpc.iter())
+            .filter_map(Some)
     }
 }

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -1,12 +1,11 @@
 use {
-    crate::ValidatorType,
+    crate::{docker::DockerImage, ValidatorType},
     k8s_openapi::{
         api::{
             apps::v1::{ReplicaSet, ReplicaSetSpec},
             core::v1::{
-                Container, EnvVar, PodSecurityContext,
-                PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Secret,
-                Volume, VolumeMount,
+                Container, EnvVar, PodSecurityContext, PodSpec, PodTemplateSpec, Probe,
+                ResourceRequirements, Secret, Volume, VolumeMount,
             },
         },
         apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
@@ -67,14 +66,13 @@ pub fn create_replica_set(
     name: &ValidatorType,
     namespace: &str,
     label_selector: &BTreeMap<String, String>,
-    container_name: &str,
-    image_name: &str,
+    image_name: &DockerImage,
     environment_variables: Vec<EnvVar>,
     command: &[String],
     volumes: Option<Vec<Volume>>,
     volume_mounts: Option<Vec<VolumeMount>>,
-    readiness_probe: Option<Probe>,
     pod_requests: BTreeMap<String, Quantity>,
+    readiness_probe: Option<Probe>,
 ) -> Result<ReplicaSet, Box<dyn Error>> {
     let pod_spec = PodTemplateSpec {
         metadata: Some(ObjectMeta {
@@ -83,7 +81,7 @@ pub fn create_replica_set(
         }),
         spec: Some(PodSpec {
             containers: vec![Container {
-                name: container_name.to_string(),
+                name: format!("{}-{}", image_name.validator_type(), "container"),
                 image: Some(image_name.to_string()),
                 image_pull_policy: Some("Always".to_string()),
                 env: Some(environment_variables),

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -4,7 +4,7 @@ use {
         api::{
             apps::v1::{ReplicaSet, ReplicaSetSpec},
             core::v1::{
-                Affinity, Container, EnvVar, PodSecurityContext,
+                Container, EnvVar, PodSecurityContext,
                 PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Secret,
                 Volume, VolumeMount,
             },

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -1,5 +1,17 @@
 use {
-    k8s_openapi::{api::core::v1::Secret, ByteString},
+    crate::ValidatorType,
+    k8s_openapi::{
+        api::{
+            apps::v1::{ReplicaSet, ReplicaSetSpec},
+            core::v1::{
+                Affinity, Container, EnvVar, PodSecurityContext,
+                PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Secret,
+                Volume, VolumeMount,
+            },
+        },
+        apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
+        ByteString,
+    },
     kube::api::ObjectMeta,
     std::{
         collections::{BTreeMap, HashMap},
@@ -48,4 +60,69 @@ pub fn create_selector(key: &str, value: &str) -> BTreeMap<String, String> {
     let mut btree = BTreeMap::new();
     btree.insert(key.to_string(), value.to_string());
     btree
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_replica_set(
+    name: &ValidatorType,
+    namespace: &str,
+    label_selector: &BTreeMap<String, String>,
+    container_name: &str,
+    image_name: &str,
+    environment_variables: Vec<EnvVar>,
+    command: &[String],
+    volumes: Option<Vec<Volume>>,
+    volume_mounts: Option<Vec<VolumeMount>>,
+    readiness_probe: Option<Probe>,
+    pod_requests: BTreeMap<String, Quantity>,
+) -> Result<ReplicaSet, Box<dyn Error>> {
+    let pod_spec = PodTemplateSpec {
+        metadata: Some(ObjectMeta {
+            labels: Some(label_selector.clone()),
+            ..Default::default()
+        }),
+        spec: Some(PodSpec {
+            containers: vec![Container {
+                name: container_name.to_string(),
+                image: Some(image_name.to_string()),
+                image_pull_policy: Some("Always".to_string()),
+                env: Some(environment_variables),
+                command: Some(command.to_owned()),
+                volume_mounts,
+                readiness_probe,
+                resources: Some(ResourceRequirements {
+                    requests: Some(pod_requests),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            volumes,
+            security_context: Some(PodSecurityContext {
+                run_as_user: Some(1000),
+                run_as_group: Some(1000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+    };
+
+    let replicas_set_spec = ReplicaSetSpec {
+        replicas: Some(1),
+        selector: LabelSelector {
+            match_labels: Some(label_selector.clone()),
+            ..Default::default()
+        },
+        template: Some(pod_spec),
+        ..Default::default()
+    };
+
+    Ok(ReplicaSet {
+        metadata: ObjectMeta {
+            name: Some(format!("{}-replicaset", name)),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: Some(replicas_set_spec),
+        ..Default::default()
+    })
 }

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -58,12 +58,12 @@ pub fn create_selector(key: &str, value: &str) -> BTreeMap<String, String> {
 
 #[allow(clippy::too_many_arguments)]
 pub fn create_replica_set(
-    name: &ValidatorType,
-    namespace: &str,
-    label_selector: &BTreeMap<String, String>,
-    image_name: &DockerImage,
+    name: ValidatorType,
+    namespace: String,
+    label_selector: BTreeMap<String, String>,
+    image_name: DockerImage,
     environment_variables: Vec<EnvVar>,
-    command: &[String],
+    command: Vec<String>,
     volumes: Option<Vec<Volume>>,
     volume_mounts: Option<Vec<VolumeMount>>,
     pod_requests: BTreeMap<String, Quantity>,
@@ -76,11 +76,11 @@ pub fn create_replica_set(
         }),
         spec: Some(PodSpec {
             containers: vec![Container {
-                name: format!("{}-{}", image_name.validator_type(), "container"),
+                name: format!("{}-container", image_name.validator_type()),
                 image: Some(image_name.to_string()),
                 image_pull_policy: Some("Always".to_string()),
                 env: Some(environment_variables),
-                command: Some(command.to_owned()),
+                command: Some(command),
                 volume_mounts,
                 readiness_probe,
                 resources: Some(ResourceRequirements {
@@ -102,7 +102,7 @@ pub fn create_replica_set(
     let replicas_set_spec = ReplicaSetSpec {
         replicas: Some(1),
         selector: LabelSelector {
-            match_labels: Some(label_selector.clone()),
+            match_labels: Some(label_selector),
             ..Default::default()
         },
         template: Some(pod_spec),
@@ -111,8 +111,8 @@ pub fn create_replica_set(
 
     Ok(ReplicaSet {
         metadata: ObjectMeta {
-            name: Some(format!("{}-replicaset", name)),
-            namespace: Some(namespace.to_string()),
+            name: Some(format!("{name}-replicaset")),
+            namespace: Some(namespace),
             ..Default::default()
         },
         spec: Some(replicas_set_spec),

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -21,11 +21,7 @@ use {
     },
     log::*,
     solana_sdk::{pubkey::Pubkey, signature::keypair::read_keypair_file, signer::Signer},
-    std::{
-        collections::{BTreeMap, HashMap},
-        error::Error,
-        path::Path,
-    },
+    std::{collections::BTreeMap, error::Error, path::Path},
 };
 
 #[derive(Debug, Clone)]
@@ -93,7 +89,7 @@ impl<'a> Kubernetes<'a> {
             .expect("Failed to read bootstrap validator keypair file");
         self.add_known_validator(bootstrap_keypair.pubkey());
 
-        let mut secrets = HashMap::new();
+        let mut secrets = BTreeMap::new();
         secrets.insert(
             "faucet".to_string(),
             SecretType::File {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -1,6 +1,12 @@
 use {
-    crate::k8s_helpers::{self, SecretType},
-    k8s_openapi::api::core::v1::{Namespace, Secret},
+    crate::k8s_helpers::{self, SecretType, ValidatorType},
+    k8s_openapi::api::{
+        apps::v1::ReplicaSet,
+        core::v1::{
+            EnvVar, EnvVarSource, Namespace, ObjectFieldSelector,
+            Secret, SecretVolumeSource, Volume, VolumeMount,
+        },
+    },
     kube::{
         api::{Api, ListParams, PostParams},
         Client,
@@ -10,6 +16,7 @@ use {
         error::Error,
         path::Path,
     },
+    log::*,
 };
 
 pub struct Kubernetes {
@@ -80,6 +87,60 @@ impl Kubernetes {
         let secrets_api: Api<Secret> =
             Api::namespaced(self.k8s_client.clone(), self.namespace.as_str());
         secrets_api.create(&PostParams::default(), secret).await
+    }
+
+    pub fn create_bootstrap_validator_replica_set(
+        &mut self,
+        container_name: &str,
+        image_name: &str,
+        secret_name: Option<String>,
+        label_selector: &BTreeMap<String, String>,
+    ) -> Result<ReplicaSet, Box<dyn Error>> {
+        let mut env_vars = vec![EnvVar {
+            name: "MY_POD_IP".to_string(),
+            value_from: Some(EnvVarSource {
+                field_ref: Some(ObjectFieldSelector {
+                    field_path: "status.podIP".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }];
+
+
+        let accounts_volume = Some(vec![Volume {
+            name: "bootstrap-accounts-volume".into(),
+            secret: Some(SecretVolumeSource {
+                secret_name,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]);
+
+        let accounts_volume_mount = Some(vec![VolumeMount {
+            name: "bootstrap-accounts-volume".to_string(),
+            mount_path: "/home/solana/bootstrap-accounts".to_string(),
+            ..Default::default()
+        }]);
+
+        let mut command =
+            vec!["/home/solana/k8s-cluster-scripts/bootstrap-startup-script.sh".to_string()];
+        command.extend(self.generate_bootstrap_command_flags());
+
+        k8s_helpers::create_replica_set(
+            &ValidatorType::Bootstrap,
+            self.namespace.as_str(),
+            label_selector,
+            container_name,
+            image_name,
+            env_vars,
+            &command,
+            accounts_volume,
+            accounts_volume_mount,
+            None,
+            self.pod_requests.requests.clone(),
+        )
     }
 
     pub fn create_selector(&self, key: &str, value: &str) -> BTreeMap<String, String> {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -1,14 +1,16 @@
 use {
     crate::{
+        docker::DockerImage,
         k8s_helpers::{self, SecretType},
-        ValidatorType, validator_config::ValidatorConfig,
+        validator_config::ValidatorConfig,
+        ValidatorType,
     },
     k8s_openapi::{
         api::{
             apps::v1::ReplicaSet,
             core::v1::{
-                EnvVar, EnvVarSource, Namespace, ObjectFieldSelector,
-                Secret, SecretVolumeSource, Volume, VolumeMount,
+                EnvVar, EnvVarSource, Namespace, ObjectFieldSelector, Secret, SecretVolumeSource,
+                Volume, VolumeMount,
             },
         },
         apimachinery::pkg::api::resource::Quantity,
@@ -17,6 +19,8 @@ use {
         api::{Api, ListParams, PostParams},
         Client,
     },
+    log::*,
+    solana_sdk::{pubkey::Pubkey, signature::keypair::read_keypair_file, signer::Signer},
     std::{
         collections::{BTreeMap, HashMap},
         error::Error,
@@ -50,8 +54,11 @@ pub struct Kubernetes<'a> {
 }
 
 impl<'a> Kubernetes<'a> {
-    pub async fn new(namespace: &str, validator_config: &'a mut ValidatorConfig, pod_requests: PodRequests
-) -> Kubernetes<'a> {
+    pub async fn new(
+        namespace: &str,
+        validator_config: &'a mut ValidatorConfig,
+        pod_requests: PodRequests,
+    ) -> Kubernetes<'a> {
         Self {
             k8s_client: Client::try_default().await.unwrap(),
             namespace: namespace.to_owned(),
@@ -73,7 +80,7 @@ impl<'a> Kubernetes<'a> {
     }
 
     pub fn create_bootstrap_secret(
-        &self,
+        &mut self,
         secret_name: &str,
         config_dir: &Path,
     ) -> Result<Secret, Box<dyn Error>> {
@@ -81,6 +88,10 @@ impl<'a> Kubernetes<'a> {
         let identity_key_path = config_dir.join("bootstrap-validator/identity.json");
         let vote_key_path = config_dir.join("bootstrap-validator/vote-account.json");
         let stake_key_path = config_dir.join("bootstrap-validator/stake-account.json");
+
+        let bootstrap_keypair = read_keypair_file(&identity_key_path)
+            .expect("Failed to read bootstrap validator keypair file");
+        self.add_known_validator(bootstrap_keypair.pubkey());
 
         let mut secrets = HashMap::new();
         secrets.insert(
@@ -111,6 +122,17 @@ impl<'a> Kubernetes<'a> {
         k8s_helpers::create_secret(secret_name, secrets)
     }
 
+    fn add_known_validator(&mut self, pubkey: Pubkey) {
+        if let Some(ref mut known_validators) = self.validator_config.known_validators {
+            known_validators.push(pubkey);
+        } else {
+            let new_known_validators = vec![pubkey];
+            self.validator_config.known_validators = Some(new_known_validators);
+        }
+
+        info!("pubkey added to known validators: {:?}", pubkey);
+    }
+
     pub async fn deploy_secret(&self, secret: &Secret) -> Result<Secret, kube::Error> {
         let secrets_api: Api<Secret> =
             Api::namespaced(self.k8s_client.clone(), self.namespace.as_str());
@@ -119,12 +141,11 @@ impl<'a> Kubernetes<'a> {
 
     pub fn create_bootstrap_validator_replica_set(
         &mut self,
-        container_name: &str,
-        image_name: &str,
+        image_name: &DockerImage,
         secret_name: Option<String>,
         label_selector: &BTreeMap<String, String>,
     ) -> Result<ReplicaSet, Box<dyn Error>> {
-        let mut env_vars = vec![EnvVar {
+        let env_vars = vec![EnvVar {
             name: "MY_POD_IP".to_string(),
             value_from: Some(EnvVarSource {
                 field_ref: Some(ObjectFieldSelector {
@@ -135,7 +156,6 @@ impl<'a> Kubernetes<'a> {
             }),
             ..Default::default()
         }];
-
 
         let accounts_volume = Some(vec![Volume {
             name: "bootstrap-accounts-volume".into(),
@@ -160,15 +180,48 @@ impl<'a> Kubernetes<'a> {
             &ValidatorType::Bootstrap,
             self.namespace.as_str(),
             label_selector,
-            container_name,
             image_name,
             env_vars,
             &command,
             accounts_volume,
             accounts_volume_mount,
-            None,
             self.pod_requests.requests.clone(),
+            None,
         )
+    }
+
+    fn generate_command_flags(&self, flags: &mut Vec<String>) {
+        if self.validator_config.tpu_enable_udp {
+            flags.push("--tpu-enable-udp".to_string());
+        }
+        if self.validator_config.tpu_disable_quic {
+            flags.push("--tpu-disable-quic".to_string());
+        }
+        if self.validator_config.skip_poh_verify {
+            flags.push("--skip-poh-verify".to_string());
+        }
+        if self.validator_config.no_snapshot_fetch {
+            flags.push("--no-snapshot-fetch".to_string());
+        }
+        if self.validator_config.require_tower {
+            flags.push("--require-tower".to_string());
+        }
+        if self.validator_config.enable_full_rpc {
+            flags.push("--enable-rpc-transaction-history".to_string());
+            flags.push("--enable-extended-tx-metadata-storage".to_string());
+        }
+
+        if let Some(limit_ledger_size) = self.validator_config.max_ledger_size {
+            flags.push("--limit-ledger-size".to_string());
+            flags.push(limit_ledger_size.to_string());
+        }
+    }
+
+    fn generate_bootstrap_command_flags(&self) -> Vec<String> {
+        let mut flags: Vec<String> = Vec::new();
+        self.generate_command_flags(&mut flags);
+
+        flags
     }
 
     pub fn create_selector(&self, key: &str, value: &str) -> BTreeMap<String, String> {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -1,5 +1,8 @@
 use {
-    crate::k8s_helpers::{self, SecretType, ValidatorType},
+    crate::{
+        k8s_helpers::{self, SecretType},
+        ValidatorType, validator_config::ValidatorConfig,
+    },
     k8s_openapi::api::{
         apps::v1::ReplicaSet,
         core::v1::{
@@ -19,16 +22,18 @@ use {
     log::*,
 };
 
-pub struct Kubernetes {
+pub struct Kubernetes<'a> {
     k8s_client: Client,
     namespace: String,
+    validator_config: &'a mut ValidatorConfig,
 }
 
-impl Kubernetes {
-    pub async fn new(namespace: &str) -> Kubernetes {
+impl<'a> Kubernetes<'a> {
+    pub async fn new(namespace: &str, validator_config: &'a mut ValidatorConfig) -> Kubernetes<'a> {
         Self {
             k8s_client: Client::try_default().await.unwrap(),
             namespace: namespace.to_owned(),
+            validator_config,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,11 @@ pub enum ValidatorType {
     Client,
 }
 
+pub mod cluster_images;
 pub mod docker;
 pub mod genesis;
 pub mod k8s_helpers;
 pub mod kubernetes;
-pub mod library;
 pub mod release;
 pub mod startup_scripts;
 pub mod validator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub async fn fetch_spl(solana_root_path: &Path) -> Result<(), Box<dyn std::error
         },
         GenesisProgram {
             name: "token-2022",
-            version: "0.9.0",
+            version: "1.0.0",
             address: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
             loader: UPGRADEABLE_LOADER,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod library;
 pub mod release;
 pub mod startup_scripts;
 pub mod validator;
+pub mod validator_config;
 
 static BUILD: Emoji = Emoji("👷 ", "");
 static PACKAGE: Emoji = Emoji("📦 ", "");

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,4 +411,17 @@ async fn main() {
         bootstrap_keypair.pubkey().to_string(),
         LabelType::Info,
     );
+
+    let bootstrap_replica_set = match kub_controller.create_bootstrap_validator_replica_set(
+        bootstrap_container_name,
+        bootstrap_image_name,
+        bootstrap_secret.metadata.name.clone(),
+        &bootstrap_rs_labels,
+    ) {
+        Ok(replica_set) => replica_set,
+        Err(err) => {
+            error!("Error creating bootstrap validator replicas_set: {}", err);
+            return;
+        }
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,13 @@ use {
     std::{fs, path::PathBuf},
     strum::VariantNames,
     validator_lab::{
+        cluster_images::ClusterImages,
         docker::{DockerConfig, DockerImage},
         genesis::{
             Genesis, GenesisFlags, DEFAULT_BOOTSTRAP_NODE_SOL, DEFAULT_BOOTSTRAP_NODE_STAKE_SOL,
             DEFAULT_FAUCET_LAMPORTS, DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         },
         kubernetes::{Kubernetes, PodRequests},
-        library::Library,
         release::{BuildConfig, BuildType, DeployMethod},
         validator::{LabelType, Validator},
         validator_config::ValidatorConfig,
@@ -444,7 +444,7 @@ async fn main() {
         .unwrap_or_default()
         .to_string();
 
-    let mut validator_library = Library::default();
+    let mut validator_library = ClusterImages::default();
 
     let bootstrap_validator = Validator::new(DockerImage::new(
         registry_name.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use {
             Genesis, GenesisFlags, DEFAULT_BOOTSTRAP_NODE_SOL, DEFAULT_BOOTSTRAP_NODE_STAKE_SOL,
             DEFAULT_FAUCET_LAMPORTS, DEFAULT_MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, DEFAULT_INTERNAL_NODE_SOL, DEFAULT_INTERNAL_NODE_STAKE_SOL,
         },
-        kubernetes::Kubernetes,
         library::Library,
+        kubernetes::{Kubernetes, PodRequests},
         release::{BuildConfig, BuildType, DeployMethod},
         validator::{LabelType, Validator},
         EnvironmentConfig,
@@ -210,6 +210,25 @@ fn parse_matches() -> clap::ArgMatches {
                 .long("full-rpc")
                 .help("Validator config. Support full RPC services on all nodes"),
         )
+        // kubernetes config
+        .arg(
+            Arg::with_name("cpu_requests")
+                .long("cpu-requests")
+                .takes_value(true)
+                .default_value("20") // 20 cores
+                .help("Kubernetes pod config. Specify minimum CPUs required for deploying validator.
+                    can use millicore notation as well. e.g. 500m (500 millicores) == 0.5 and is equivalent to half a core.
+                    [default: 20]"),
+        )
+        .arg(
+            Arg::with_name("memory_requests")
+                .long("memory-requests")
+                .takes_value(true)
+                .default_value("70Gi") // 70 Gigabytes
+                .help("Kubernetes pod config. Specify minimum memory required for deploying validator.
+                    Can specify unit here (B, Ki, Mi, Gi, Ti) for bytes, kilobytes, etc (2^N notation)
+                    e.g. 1Gi == 1024Mi == 1024Ki == 1,047,576B. [default: 70Gi]"),
+        )
         .get_matches()
 }
 
@@ -349,7 +368,12 @@ async fn main() {
         known_validators: None,
     };
 
-    let kub_controller = Kubernetes::new(environment_config.namespace, &mut validator_config).await;
+    let pod_requests = PodRequests::new(
+        matches.value_of("cpu_requests").unwrap().to_string(),
+        matches.value_of("memory_requests").unwrap().to_string(),
+    );
+
+    let kub_controller = Kubernetes::new(environment_config.namespace, &mut validator_config, pod_requests).await;
     match kub_controller.namespace_exists().await {
         Ok(true) => (),
         Ok(false) => {

--- a/src/startup_scripts.rs
+++ b/src/startup_scripts.rs
@@ -75,12 +75,6 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --tpu-disable-quic ]]; then
-      args+=("$1")
-      shift
-    elif [[ $1 = --tpu-enable-udp ]]; then
-      args+=("$1")
-      shift
     elif [[ $1 = --rpc-send-batch-ms ]]; then # not enabled in net.sh
       args+=("$1" "$2")
       shift 2

--- a/src/validator_config.rs
+++ b/src/validator_config.rs
@@ -1,0 +1,56 @@
+use solana_sdk::{
+    hash::Hash, pubkey::Pubkey, 
+};
+
+pub struct ValidatorConfig {
+    pub tpu_enable_udp: bool,
+    pub tpu_disable_quic: bool,
+    pub shred_version: Option<u16>,
+    pub bank_hash: Option<Hash>,
+    pub max_ledger_size: Option<u64>,
+    pub skip_poh_verify: bool,
+    pub no_snapshot_fetch: bool,
+    pub require_tower: bool,
+    pub enable_full_rpc: bool,
+    pub entrypoints: Vec<String>,
+    pub known_validators: Option<Vec<Pubkey>>,
+}
+
+impl std::fmt::Display for ValidatorConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let known_validators = match &self.known_validators {
+            Some(validators) => validators
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            None => "None".to_string(),
+        };
+        write!(
+            f,
+            "Runtime Config\n\
+             tpu_enable_udp: {}\n\
+             tpu_disable_quic: {}\n\
+             shred_version: {:?}\n\
+             bank_hash: {:?}\n\
+             max_ledger_size: {:?}\n\
+             skip_poh_verify: {}\n\
+             no_snapshot_fetch: {}\n\
+             require_tower: {}\n\
+             enable_full_rpc: {}\n\
+             entrypoints: {:?}\n\
+             known_validators: {:?}",
+            self.tpu_enable_udp,
+            self.tpu_disable_quic,
+            self.shred_version,
+            self.bank_hash,
+            self.max_ledger_size,
+            self.skip_poh_verify,
+            self.no_snapshot_fetch,
+            self.require_tower,
+            self.enable_full_rpc,
+            self.entrypoints.join(", "),
+            known_validators,
+        )
+    }
+}

--- a/src/validator_config.rs
+++ b/src/validator_config.rs
@@ -1,18 +1,13 @@
-use solana_sdk::{
-    hash::Hash, pubkey::Pubkey, 
-};
+use solana_sdk::pubkey::Pubkey;
 
 pub struct ValidatorConfig {
     pub tpu_enable_udp: bool,
     pub tpu_disable_quic: bool,
-    pub shred_version: Option<u16>,
-    pub bank_hash: Option<Hash>,
     pub max_ledger_size: Option<u64>,
     pub skip_poh_verify: bool,
     pub no_snapshot_fetch: bool,
     pub require_tower: bool,
     pub enable_full_rpc: bool,
-    pub entrypoints: Vec<String>,
     pub known_validators: Option<Vec<Pubkey>>,
 }
 
@@ -31,25 +26,19 @@ impl std::fmt::Display for ValidatorConfig {
             "Runtime Config\n\
              tpu_enable_udp: {}\n\
              tpu_disable_quic: {}\n\
-             shred_version: {:?}\n\
-             bank_hash: {:?}\n\
              max_ledger_size: {:?}\n\
              skip_poh_verify: {}\n\
              no_snapshot_fetch: {}\n\
              require_tower: {}\n\
              enable_full_rpc: {}\n\
-             entrypoints: {:?}\n\
              known_validators: {:?}",
             self.tpu_enable_udp,
             self.tpu_disable_quic,
-            self.shred_version,
-            self.bank_hash,
             self.max_ledger_size,
             self.skip_poh_verify,
             self.no_snapshot_fetch,
             self.require_tower,
             self.enable_full_rpc,
-            self.entrypoints.join(", "),
             known_validators,
         )
     }

--- a/src/validator_config.rs
+++ b/src/validator_config.rs
@@ -1,45 +1,11 @@
 use solana_sdk::pubkey::Pubkey;
 
+#[derive(Debug)]
 pub struct ValidatorConfig {
-    pub tpu_enable_udp: bool,
-    pub tpu_disable_quic: bool,
     pub max_ledger_size: Option<u64>,
     pub skip_poh_verify: bool,
     pub no_snapshot_fetch: bool,
     pub require_tower: bool,
     pub enable_full_rpc: bool,
-    pub known_validators: Option<Vec<Pubkey>>,
-}
-
-impl std::fmt::Display for ValidatorConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let known_validators = match &self.known_validators {
-            Some(validators) => validators
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-            None => "None".to_string(),
-        };
-        write!(
-            f,
-            "Runtime Config\n\
-             tpu_enable_udp: {}\n\
-             tpu_disable_quic: {}\n\
-             max_ledger_size: {:?}\n\
-             skip_poh_verify: {}\n\
-             no_snapshot_fetch: {}\n\
-             require_tower: {}\n\
-             enable_full_rpc: {}\n\
-             known_validators: {:?}",
-            self.tpu_enable_udp,
-            self.tpu_disable_quic,
-            self.max_ledger_size,
-            self.skip_poh_verify,
-            self.no_snapshot_fetch,
-            self.require_tower,
-            self.enable_full_rpc,
-            known_validators,
-        )
-    }
+    pub known_validators: Vec<Pubkey>,
 }


### PR DESCRIPTION
#### Summary of Changes
1) create bootstrap validator replicaset
2) Update token-2022 to v1.0.0
3) address a few nits from PR: #9 
4) `Library` is now `ClusterImages` and its structure is slightly changed

10th PR in a series of PRs that will build out the monogon testing framework for deploying validator clusters on Kubernetes