### PR TITLE
switch docker tag to commit/release-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ cargo run --bin cluster --
     --slots-per-epoch <slots-per-epoch>
     # docker config
     --registry <docker-registry>        # e.g. gregcusack 
-    --tag <docker-image-tag>            # e.g. v1
     --base-image <base-image>           # e.g. ubuntu:20.04
     --image-name <docker-image-name>    # e.g. cluster-image
     # validator config

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -18,7 +18,7 @@ pub struct DockerImage {
     registry: String,
     validator_type: ValidatorType,
     image_name: String,
-    tag: String,
+    tag: String, // commit (`abcd1234`) or version (`v1.18.12`)
 }
 
 impl DockerImage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub fn cat_file(path: &PathBuf) -> std::io::Result<()> {
     let mut file = File::open(path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
-    info!("{:?}:\n{contents}", path.file_name());
+    debug!("{:?}:\n{contents}", path.file_name());
 
     Ok(())
 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -137,11 +137,7 @@ impl BuildConfig {
         std::fs::write(self.solana_root_path.join("farf/version.yml"), content)
             .expect("Failed to write version.yml");
 
-        let label = if let Some(tag) = commit_tag {
-            tag
-        } else {
-            commit.to_string()[..8].to_string()
-        };
+        let label = commit_tag.unwrap_or_else(|| commit.to_string()[..8].to_string());
 
         info!("Build took {:.3?} seconds", start_time.elapsed());
         Ok(label)

--- a/src/startup_scripts.rs
+++ b/src/startup_scripts.rs
@@ -591,8 +591,6 @@ run_delegate_stake() {
     fi
     echo "delegated stake"
   fi
-
-  solana --url $LOAD_BALANCER_RPC_URL --keypair $IDENTITY_FILE stakes validator-accounts/stake.json
 }
 
 echo "get airdrop and create vote account"

--- a/src/startup_scripts.rs
+++ b/src/startup_scripts.rs
@@ -591,6 +591,8 @@ run_delegate_stake() {
     fi
     echo "delegated stake"
   fi
+
+  solana --url $LOAD_BALANCER_RPC_URL --keypair $IDENTITY_FILE stake-account validator-accounts/stake.json
 }
 
 echo "get airdrop and create vote account"


### PR DESCRIPTION
1) Changed how tags are implemented
- now, tags are not set by user but set by the local-path commit or the release-channel version
    - if local-path commit is associated with a release version, the release version will be used as the docker tag

2) Removed `--skip-docker-build`
- pretty redundant. If we have `--build-type` skip, we don't need `--skip-docker-build`. If we are not building the local-repo or release channel, then we don't need to build and push a docker image