### PR TITLE
use version tag in service, replicaset, and secret names

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -40,6 +40,10 @@ impl DockerImage {
     pub fn validator_type(&self) -> ValidatorType {
         self.validator_type
     }
+
+    pub fn tag(&self) -> String {
+        self.tag.clone()
+    }
 }
 
 // Put DockerImage in format for building, pushing, and pulling


### PR DESCRIPTION
Goal over the next couple PRs is to enable heterogeneous clusters. 
This PR adds a version tag (commit hash/release version) to validator/client services, replicasets, secrets. 
- Leaves bootstrap and load balancer service names intact since there is only one bootstrap service and one load balancer service

The next PR will allow us to deploy another set of validators/clients (with a different validator version) into an already running cluster. 

Side note: turns there was a bug in the previous PR. We can't skip building and pushing docker images since we create a new genesis on each run. And each genesis includes client accounts and the bootstrap account. There is a way around this but doesn't feel like it is worth the time right now to implement. and the benefit isn't huge. So I removed the `if build_type != BuildType::Skip { ... }` 