### PR TITLE
move validator-only flag. change default base image to ubuntu:22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In Validator Lab we can deploy and test new validator features quickly and easil
 ## How to run
 
 ### Setup
-Ensure you have the proper permissions to conenct to the Monogon Kubernetes endpoint. Reach out to Leo on slack if you need the key (you do if you haven't asked him in the past).
+Ensure you have the proper permissions to connect to the Monogon Kubernetes endpoint. Reach out to Leo on slack if you need the key (you do if you haven't asked him in the past).
 
 From your local build host, login to Docker for pushing/pulling repos. Currently we just use the users own Docker login. This will likely change in the future.
 ```
@@ -45,6 +45,7 @@ cargo run --bin cluster --
 3) Validator, client, and rpc Dockerfiles
 
 After deploying a cluster with a bootstrap, 2 clients, 2 validators, and 3 rpc nodes all running v1.18.13, your `<cluster-data-path>` directory will look something like:
+
 ![Cluster Data Path Directory](cluster_data_path_tree.png)
 
 #### Build from Local Repo and Configure Genesis and Bootstrap and Validator Image

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn parse_matches() -> clap::ArgMatches {
             Arg::with_name("base_image")
                 .long("base-image")
                 .takes_value(true)
-                .default_value("ubuntu:20.04")
+                .default_value("ubuntu:22.04")
                 .help("Docker base image"),
         )
         // Bootstrap/Validator Config

--- a/src/release.rs
+++ b/src/release.rs
@@ -107,9 +107,9 @@ impl BuildConfig {
 
             let install_script = agave_path.join("scripts/cargo-install-all.sh");
             match std::process::Command::new(install_script)
+                .arg("--validator-only")
                 .arg(self.install_directory.clone())
                 .arg(build_variant)
-                .arg("--validator-only")
                 .status()
             {
                 Ok(result) => {


### PR DESCRIPTION
for some reason maybe due to a rust change, the --validator-only flag on solana build stopped getting passed in. So moved it in front of the target directory and it works again now. Also changed default base image to ubuntu:22.04

also fix a typo and reformat image in readme