### PR TITLE
Use agave release channels

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -275,7 +275,7 @@ impl BuildConfig {
         }
 
         let download_url = format!(
-            "https://release.solana.com/{release_channel}/solana-release-x86_64-unknown-linux-gnu.tar.bz2"
+            "https://release.anza.xyz/{release_channel}/solana-release-x86_64-unknown-linux-gnu.tar.bz2"
         );
         info!("download_url: {download_url}");
 


### PR DESCRIPTION
The `--release-channel` flag calls to `release.solana.com`, which doesn't really support releases beyond v1.18 (current stable). This PR updates the code to use `release.anza.xyz` instead (although I suppose we could make it configurable).