### PR TITLE
Make rpc nodes enable_full_rpc

### DIFF
--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -306,6 +306,7 @@ impl<'a> Kubernetes<'a> {
         if self.validator_config.enable_full_rpc {
             flags.push("--enable-rpc-transaction-history".to_string());
             flags.push("--enable-extended-tx-metadata-storage".to_string());
+            flags.push("--full-rpc-api".to_string());
         }
 
         if let Some(limit_ledger_size) = self.validator_config.max_ledger_size {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -293,6 +293,12 @@ impl<'a> Kubernetes<'a> {
         )
     }
 
+    fn generate_full_rpc_flags(flags: &mut Vec<String>) {
+        flags.push("--enable-rpc-transaction-history".to_string());
+        flags.push("--enable-extended-tx-metadata-storage".to_string());
+        flags.push("--full-rpc-api".to_string());
+    }
+
     fn generate_command_flags(&self, flags: &mut Vec<String>) {
         if self.validator_config.skip_poh_verify {
             flags.push("--skip-poh-verify".to_string());
@@ -304,9 +310,7 @@ impl<'a> Kubernetes<'a> {
             flags.push("--require-tower".to_string());
         }
         if self.validator_config.enable_full_rpc {
-            flags.push("--enable-rpc-transaction-history".to_string());
-            flags.push("--enable-extended-tx-metadata-storage".to_string());
-            flags.push("--full-rpc-api".to_string());
+            Self::generate_full_rpc_flags(flags);
         }
 
         if let Some(limit_ledger_size) = self.validator_config.max_ledger_size {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -309,9 +309,6 @@ impl<'a> Kubernetes<'a> {
         if self.validator_config.require_tower {
             flags.push("--require-tower".to_string());
         }
-        if self.validator_config.enable_full_rpc {
-            Self::generate_full_rpc_flags(flags);
-        }
 
         if let Some(limit_ledger_size) = self.validator_config.max_ledger_size {
             flags.push("--limit-ledger-size".to_string());
@@ -322,6 +319,9 @@ impl<'a> Kubernetes<'a> {
     fn generate_bootstrap_command_flags(&self) -> Vec<String> {
         let mut flags: Vec<String> = Vec::new();
         self.generate_command_flags(&mut flags);
+        if self.validator_config.enable_full_rpc {
+            Self::generate_full_rpc_flags(&mut flags);
+        }
 
         flags
     }
@@ -533,6 +533,9 @@ impl<'a> Kubernetes<'a> {
     fn generate_validator_command_flags(&self) -> Vec<String> {
         let mut flags: Vec<String> = Vec::new();
         self.generate_command_flags(&mut flags);
+        if self.validator_config.enable_full_rpc {
+            Self::generate_full_rpc_flags(&mut flags);
+        }
 
         flags.push("--internal-node-stake-sol".to_string());
         flags.push(self.validator_config.internal_node_stake_sol.to_string());
@@ -608,6 +611,7 @@ impl<'a> Kubernetes<'a> {
             flags.push("--expected-shred-version".to_string());
             flags.push(shred_version.to_string());
         }
+        Self::generate_full_rpc_flags(&mut flags);
 
         self.add_known_validators_if_exists(&mut flags);
 


### PR DESCRIPTION
I was surprised that my RPC node didn't not support the full api. I could turn this on for the whole cluster with the `--full-rpc` cli flag, but it makes sense to me to allow voting validators to run without it.

Changes in this PR:
-Add `--full-rpc-api` to set of `enable_full_rpc` node flags. This should probably be merged regardless, because I think it is the intent of the `enable_full_rpc` config.
- Always boot RPC nodes with `enable_full_rpc` flags. Only boot bootstrap and other voting validators with full rpc if `--full-rpc` is provided on boot. This is more controversial. We could add separate cli handling for rpc vs voting nodes to opt in/out of full-rpc. But I think most users will want RPC nodes to have full support.