### PR TITLE
Remove unsupported full-rpc-api startup_scripts flag

### DIFF
--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -296,7 +296,6 @@ impl<'a> Kubernetes<'a> {
     fn generate_full_rpc_flags(flags: &mut Vec<String>) {
         flags.push("--enable-rpc-transaction-history".to_string());
         flags.push("--enable-extended-tx-metadata-storage".to_string());
-        flags.push("--full-rpc-api".to_string());
     }
 
     fn generate_command_flags(&self, flags: &mut Vec<String>) {


### PR DESCRIPTION
https://github.com/anza-xyz/validator-lab/pull/53 broke rpc-node and `enable_full_rpc` validator deployment because the bash scripts built by `startup_scripts.rs` don't recognize the `--full-rpc-api` flag.
Greg is working on a more correct solution, but in the meantime, unbreak things by removing the bad flag.