### PR TITLE
Add stake to internal_node_sol

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -500,10 +500,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ),
     };
 
+    let internal_node_stake_sol = value_t_or_exit!(matches, "internal_node_stake_sol", f64);
+    let internal_node_sol =
+        value_t_or_exit!(matches, "internal_node_sol", f64) + internal_node_stake_sol;
+
     let limit_ledger_size = value_t_or_exit!(matches, "limit_ledger_size", u64);
     let mut validator_config = ValidatorConfig {
-        internal_node_sol: value_t_or_exit!(matches, "internal_node_sol", f64),
-        internal_node_stake_sol: value_t_or_exit!(matches, "internal_node_stake_sol", f64),
+        internal_node_sol,
+        internal_node_stake_sol,
         shred_version: None, // set after genesis created
         max_ledger_size: if limit_ledger_size < DEFAULT_MIN_MAX_LEDGER_SHREDS {
             clap::Error::with_description(


### PR DESCRIPTION
The stake delegated to additional (non-bootstrap) validators is funded by each of those node's respective identity key. This means that if you choose an `--internal-node-stake-sol` value that is larger than the default value for `--internal-node-sol`, the stake delegation will fail and the node will not boot. This is an annoying thing to have to remember, particularly because the `--bootstrap-validator-sol` and `--bootstrap-validator-stake-sol` args do not have this same requirement.

Update `internal_node_sol` to equal the value provided by the `--internal-node-sol` plus `internal_node_stake_sol` so that the id account always has enough to cover the delegation, and the remaining amount is (close to*) the configured internal node sol. (*close to, but not exact, due to transaction fees)