### PR TITLE
Add commission arg

### DIFF
--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -63,6 +63,7 @@ pub struct GenesisFlags {
     pub cluster_type: String,
     pub bootstrap_validator_sol: Option<f64>,
     pub bootstrap_validator_stake_sol: Option<f64>,
+    pub commission: u8,
 }
 
 impl std::fmt::Display for GenesisFlags {
@@ -358,6 +359,8 @@ impl Genesis {
                         format!("Invalid Unicode data in path: {:?}", err),
                     )
                 })?,
+            "--vote-commission-percentage".to_string(),
+            self.flags.commission.to_string(),
         ];
 
         if self.flags.enable_warmup_epochs {

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -539,6 +539,9 @@ impl<'a> Kubernetes<'a> {
         flags.push("--internal-node-stake-sol".to_string());
         flags.push(self.validator_config.internal_node_stake_sol.to_string());
 
+        flags.push("--commission".to_string());
+        flags.push(self.validator_config.commission.to_string());
+
         flags.push("--internal-node-sol".to_string());
         flags.push(self.validator_config.internal_node_sol.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,14 @@ fn parse_matches() -> clap::ArgMatches {
                 .default_value(&DEFAULT_INTERNAL_NODE_STAKE_SOL.to_string())
                 .help("Amount to stake internal nodes (Sol)."),
         )
+        .arg(
+            Arg::with_name("commission")
+                .long("commission")
+                .value_name("PERCENTAGE")
+                .takes_value(true)
+                .default_value("100")
+                .help("The commission taken by nodes on staking rewards (0-100) [default: 100]")
+        )
         //RPC config
         .arg(
             Arg::with_name("number_of_rpc_nodes")
@@ -450,6 +458,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cluster_data_root.get_root_path(),
     );
 
+    let commission = value_t_or_exit!(matches, "commission", u8);
+
     let genesis_flags = GenesisFlags {
         hashes_per_tick: matches
             .value_of("hashes_per_tick")
@@ -498,6 +508,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .expect("Invalid value for bootstrap_validator_stake_sol")
             },
         ),
+        commission,
     };
 
     let internal_node_stake_sol = value_t_or_exit!(matches, "internal_node_stake_sol", f64);
@@ -508,6 +519,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut validator_config = ValidatorConfig {
         internal_node_sol,
         internal_node_stake_sol,
+        commission,
         shred_version: None, // set after genesis created
         max_ledger_size: if limit_ledger_size < DEFAULT_MIN_MAX_LEDGER_SHREDS {
             clap::Error::with_description(

--- a/src/startup_scripts.rs
+++ b/src/startup_scripts.rs
@@ -230,6 +230,7 @@ args=(
 airdrops_enabled=1
 node_sol=
 stake_sol=
+commission=
 identity=validator-accounts/identity.json
 vote_account=validator-accounts/vote.json
 no_restart=0
@@ -287,6 +288,9 @@ while [[ -n $1 ]]; do
       shift
     elif [[ $1 == --internal-node-stake-sol ]]; then
       stake_sol=$2
+      shift 2
+    elif [[ $1 == --commission ]]; then
+      commission=$2
       shift 2
     elif [[ $1 == --internal-node-sol ]]; then
       node_sol=$2
@@ -559,7 +563,7 @@ setup_validator() {
     exit 1
   fi
 
-  if ! run_solana_command "solana -u $LOAD_BALANCER_RPC_URL create-vote-account --allow-unsafe-authorized-withdrawer validator-accounts/vote.json $IDENTITY_FILE $IDENTITY_FILE -k $IDENTITY_FILE" "Create Vote Account"; then
+  if ! run_solana_command "solana -u $LOAD_BALANCER_RPC_URL create-vote-account --allow-unsafe-authorized-withdrawer validator-accounts/vote.json $IDENTITY_FILE $IDENTITY_FILE -k $IDENTITY_FILE --commission $commission" "Create Vote Account"; then
     if $vote_account_already_exists; then
       echo "Vote account already exists. Skipping remaining commands."
     else

--- a/src/validator_config.rs
+++ b/src/validator_config.rs
@@ -4,6 +4,7 @@ use solana_sdk::pubkey::Pubkey;
 pub struct ValidatorConfig {
     pub internal_node_sol: f64,
     pub internal_node_stake_sol: f64,
+    pub commission: u8,
     pub shred_version: Option<u16>,
     pub max_ledger_size: Option<u64>,
     pub skip_poh_verify: bool,


### PR DESCRIPTION
In order to test staking rewards, we need clusters of validators with less than 100% commission.

Add commission cli arg; the default value is `100`, which is the same default that `solana-genesis` and `solana create-vote-account` use if no `--vote-commission-percentage` or `--commission` argument is present (respectively).
The same commission value applies to the vote accounts of all nodes in the cluster.