### PR TITLE
Configure solana to use local url on RPC nodes

### DIFF
--- a/src/startup_scripts.rs
+++ b/src/startup_scripts.rs
@@ -836,6 +836,9 @@ while [[ -n $1 ]]; do
 done
 
 echo "post positional args"
+
+solana config set -ul
+
 if [[ "$SOLANA_GPU_MISSING" -eq 1 ]]; then
     echo "Testnet requires GPUs, but none were found!  Aborting..."
     exit 1


### PR DESCRIPTION
Just a small nicety. Assumes that if you are logged into an RPC node, you want to query that local node, not mnb (which is the solana-cli default).
Could do this on the other node types as well (set to load balancer or whatever makes the most sense), but I don't feel strongly.