### PR TITLE
add external ip/port for load balancer for RPC queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Note: We can't deploy heterogeneous clusters across v1.17 and v1.18 due to featu
 
 ## Querying the RPC from outside the cluster
 The cluster now has an external IP/port that can be queried to reach the cluster RPC. The external RPC port is 30000.
-1) Get one of the node ips. Can pick anyone: 
+1) Get any one of the node IPs in the cluster. Querying the RPC will work with any node IP in the cluster, this includes nodes that are NOT running any of your pods:
 ```
 kubectl get nodes -o wide
 ```

--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ For steps (2) and (3), when using `--no-bootstrap`, we assume that the directory
 
 Note: We can't deploy heterogeneous clusters across v1.17 and v1.18 due to feature differences. Hope to fix this in the future. Have something where we can specifically define which features to enable.
 
+## Querying the RPC from outside the cluster
+The cluster now has an external IP/port that can be queried to reach the cluster RPC. The external RPC port is 30000.
+1) Get one of the node ips. Can pick anyone: 
+```
+kubectl get nodes -o wide
+```
+2) Run your query. e.g.
+```
+curl -X POST \
+-H "Content-Type: application/json" \
+-d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "getClusterNodes"
+    }' \
+http://<node-ip>:30000
+```
+
 ## Kubernetes Cheatsheet
 Create namespace:
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ For steps (2) and (3), when using `--no-bootstrap`, we assume that the directory
 Note: We can't deploy heterogeneous clusters across v1.17 and v1.18 due to feature differences. Hope to fix this in the future. Have something where we can specifically define which features to enable.
 
 ## Querying the RPC from outside the cluster
-The cluster now has an external IP/port that can be queried to reach the cluster RPC. The external RPC port is 30000.
+The cluster now has an external IP/port that can be queried to reach the cluster RPC. The external RPC port will be logged during cluster boot, e.g.:
+```
+Deploying Load Balancer Service with external port: 30000
+```
 1) Get any one of the node IPs in the cluster. Querying the RPC will work with any node IP in the cluster, this includes nodes that are NOT running any of your pods:
 ```
 kubectl get nodes -o wide
@@ -172,7 +175,7 @@ curl -X POST \
     "id": 1,
     "method": "getClusterNodes"
     }' \
-http://<node-ip>:30000
+http://<node-ip>:<external-port>
 ```
 
 ## Kubernetes Cheatsheet

--- a/src/k8s_helpers.rs
+++ b/src/k8s_helpers.rs
@@ -149,6 +149,7 @@ pub fn create_service(
                 ServicePort {
                     port: 8899, // RPC Port
                     name: Some("rpc-port".to_string()),
+                    node_port: if is_load_balancer { Some(30000) } else { None },
                     ..Default::default()
                 },
                 ServicePort {

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,10 +755,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let load_balancer_label =
             kub_controller.create_selector("load-balancer/name", "load-balancer-selector");
         //create load balancer
-        let load_balancer = kub_controller.create_validator_load_balancer(
-            "bootstrap-and-rpc-node-lb-service",
-            &load_balancer_label,
-        );
+        let load_balancer = kub_controller
+            .create_validator_load_balancer(
+                "bootstrap-and-rpc-node-lb-service",
+                &load_balancer_label,
+            )
+            .await?;
 
         //deploy load balancer
         kub_controller.deploy_service(&load_balancer).await?;


### PR DESCRIPTION
The cluster now has an external IP/port that can be queried to reach the cluster RPC. The external RPC port is 30000.
1) Get one of the node ips. Can pick anyone: 
```
kubectl get nodes -o wide
```
2) Run your query. e.g.
```
curl -X POST \
-H "Content-Type: application/json" \
-d '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getClusterNodes"
    }' \
http://<node-ip>:30000
```