### PR TITLE
Add --no-restart flag

### DIFF
--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -329,6 +329,9 @@ impl<'a> Kubernetes<'a> {
         if self.validator_config.require_tower {
             flags.push("--require-tower".to_string());
         }
+        if !self.validator_config.restart {
+            flags.push("--no-restart".to_string());
+        }
 
         if let Some(limit_ledger_size) = self.validator_config.max_ledger_size {
             flags.push("--limit-ledger-size".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,12 @@ fn parse_matches() -> clap::ArgMatches {
                 .default_value("100")
                 .help("The commission taken by nodes on staking rewards (0-100)")
         )
+        .arg(
+            Arg::with_name("no_restart")
+                .long("no-restart")
+                .help("Validator config. If set, validators will not restart after \
+                       exiting for any reason."),
+        )
         //RPC config
         .arg(
             Arg::with_name("number_of_rpc_nodes")
@@ -535,6 +541,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         require_tower: matches.is_present("require_tower"),
         enable_full_rpc: matches.is_present("enable_full_rpc"),
         known_validators: vec![],
+        restart: !matches.is_present("no_restart"),
     };
 
     if num_rpc_nodes == 0 && !validator_config.enable_full_rpc {

--- a/src/validator_config.rs
+++ b/src/validator_config.rs
@@ -12,4 +12,5 @@ pub struct ValidatorConfig {
     pub require_tower: bool,
     pub enable_full_rpc: bool,
     pub known_validators: Vec<Pubkey>,
+    pub restart: bool,
 }


### PR DESCRIPTION
I want to test things like booting from a specific snapshot, so it would be handy to have the old `/net` ability to turn off automatic node restarts. `startup_scripts.rs` already supports a `--no-restart` flag.

I'm open to discussion on the best way to do this. It would actually be nice to have this configurable per node, but it serves my purposes for now to have a single hammer. Wdyt?